### PR TITLE
Fix/Facebook graph response

### DIFF
--- a/Sources/Facebook/FacebookAuthenticator+Models.swift
+++ b/Sources/Facebook/FacebookAuthenticator+Models.swift
@@ -22,6 +22,18 @@ public extension FacebookAuthenticator {
     let email: String?
     let firstName: String?
     let lastName: String?
+    let picture: PictureData?
+
+    struct PictureData: Decodable {
+      let data: PictureURL
+    }
+
+    struct PictureURL: Decodable {
+      let isSilhouette: Bool
+      let width: Int
+      let url: String
+      let height: Int
+    }
   }
 }
 

--- a/Sources/Facebook/FacebookAuthenticator.swift
+++ b/Sources/Facebook/FacebookAuthenticator.swift
@@ -104,19 +104,11 @@ private extension FacebookAuthenticator {
       request.start { _, result, error in
         switch result {
         case .some(let response):
-          guard let dict = response as? [String: String] else {
-            seal.reject(with: Error.invalidUserData)
-            return
-          }
-          
           let decoder = JSONDecoder()
           decoder.keyDecodingStrategy = .convertFromSnakeCase
           
-          let encoder = JSONEncoder()
-          encoder.keyEncodingStrategy = .convertToSnakeCase
-          
           do {
-            let data = try encoder.encode(dict)
+            let data = try JSONSerialization.data(withJSONObject: response, options: [])
             let object = try data.decode(GraphResponse.self, with: decoder)
             
             let authResponse = Response(


### PR DESCRIPTION
New Facebook SDK has updated the graph response for fetching user details and this PR addresses an issue where facebook sign in was failing (because of decoding failure).