### PR TITLE
Apple/Nullable value

### DIFF
--- a/Sources/Apple/AppleAuthenticator+Models.swift
+++ b/Sources/Apple/AppleAuthenticator+Models.swift
@@ -23,10 +23,11 @@ public extension AppleAuthenticator {
     public let email: Email
     public let expiresAt: Date
 
-    public var name: String {
-      [nameComponents?.givenName, nameComponents?.familyName]
+    public var name: String? {
+      let fullName = [nameComponents?.givenName, nameComponents?.familyName]
         .compactMap { $0 }
         .joined(separator: " ")
+      return !fullName.isEmpty ? fullName : nil
     }
   }
   

--- a/Sources/Apple/AppleAuthenticator+Models.swift
+++ b/Sources/Apple/AppleAuthenticator+Models.swift
@@ -22,12 +22,16 @@ public extension AppleAuthenticator {
     public let nameComponents: PersonNameComponents?
     public let email: Email
     public let expiresAt: Date
-
+    
+    /// User full name represented by `givenName` and `familyName`
     public var name: String? {
-      let fullName = [nameComponents?.givenName, nameComponents?.familyName]
-        .compactMap { $0 }
-        .joined(separator: " ")
-      return !fullName.isEmpty ? fullName : nil
+      guard let givenName = nameComponents?.givenName else {
+        return nameComponents?.familyName
+      }
+      guard let familyName = nameComponents?.familyName else {
+        return givenName
+      }
+      return "\(givenName) \(familyName)"
     }
   }
   


### PR DESCRIPTION
Since nameComponents and it's values can be null, we should return null value for `name` as well.