### PR TITLE
Use SHA256 for custom nonce as well

### DIFF
--- a/Sources/Apple/AppleAuthenticator.swift
+++ b/Sources/Apple/AppleAuthenticator.swift
@@ -147,7 +147,7 @@ private extension AppleAuthenticator {
       }
       request.nonce = generateNonceString(length: length).sha256
     case .custom(let value):
-      request.nonce = value
+      request.nonce = value.sha256
     case .none:
       break
     }


### PR DESCRIPTION
- Convert the custom nonce to SHA256 as well

Fixes an issue, where setting custom nonce with Firebase and PovioKitAuth resulted in an error, saying that the nonce on FirebaseAuth and PovioKitAuth were not matching:

```
The nonce in ID Token "zyx" does not match the SHA256 hash of the raw nonce "zyx" in the request.
```