### PR TITLE
Chore/Updates

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -24,8 +24,8 @@ jobs:
         xcode-version: latest-stable
 
     - name: Build project
-      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild build-for-testing -destination 'name=iPhone 17 Pro,OS=26.0' -scheme 'PovioKitAuth-Package' | xcpretty
+      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild build-for-testing -destination 'name=iPhone 17 Pro,OS=26.4' -scheme 'PovioKitAuth-Package' | xcpretty
 
     - name: Run tests
-      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild test-without-building -destination 'name=iPhone 17 Pro,OS=26.0' -scheme 'PovioKitAuth-Package' | xcpretty
+      run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild test-without-building -destination 'name=iPhone 17 Pro,OS=26.4' -scheme 'PovioKitAuth-Package' | xcpretty
 

--- a/README.md
+++ b/README.md
@@ -27,12 +27,14 @@
 | [Core](Resources/Core) | [Apple](Resources/Apple) | [Google](Resources/Google) | [Facebook](Resources/Facebook) | [LinkedIn](Resources/LinkedIn) |
 | :-: | :-: | :-: | :-: | :-: |
 
+Google and Facebook providers were extracted into separate packages. See [Migration](MIGRATING.md).
+
 ## Installation
 
 ### Swift Package Manager
 - In Xcode, click `File` -> `Add Packages...`  
 - Insert `https://github.com/poviolabs/PovioKitAuth` in the Search field.
-- Select a desired `Dependency Rule`. Usually "Up to Next Major Version" with "2.1.0".
+- Select a desired `Dependency Rule` (usually "Up to Next Major Version").
 - Select "Add Package" button and check one or all given products from the list:
   - *PovioKitAuthCore* (core library)
   - *PovioKitAuthApple* (Apple auth components)
@@ -50,7 +52,7 @@ You can leverage use of `SocialAuthenticationManager` as to simplify managing mu
 ```swift
 import PovioKitAuthCore
 import PovioKitAuthApple
-import PovioKitAuthFacebook
+import PovioKitAuthLinkedIn
 
 let manager = SocialAuthenticationManager(authenticators: [AppleAuthenticator(), LinkedInAuthenticator()])
 
@@ -59,13 +61,13 @@ let appleAuthenticator = manager.authenticator(for: AppleAuthenticator.self)
 let result = try await appleAuthenticator?
   .signIn(from: <view-controller-instance>, with: .random(length: 32))
   
-// signIn user with Facebook
-let facebookAuthenticator = manager.authenticator(for: FacebookAuthenticator.self)
-let result = try await facebookAuthenticator?
-  .signIn(from: <view-controller-instance>, with: [.email])
+// signIn user with LinkedIn
+let linkedInAuthenticator = manager.authenticator(for: LinkedInAuthenticator.self)
+let result = try await linkedInAuthenticator?
+  .signIn(authCode: <authorization-code>, configuration: <configuration>)
   
 // return currently authenticated authenticator
-let authenticated: Authenticator? = manager.authenticator
+let authenticated: Authenticator? = manager.currentAuthenticator
 
 // sign out currently signedIn authenticator
 manager.signOut()
@@ -85,13 +87,12 @@ final class WrapperManager {
   init() {
     socialAuthManager = SocialAuthenticationManager(authenticators: [
       AppleAuthenticator(),
-      GoogleAuthenticator(),
-      SnapchatAuthenticator()
+      LinkedInAuthenticator()
     ])
   }
 }
 
-extension AuthManager: Authenticator {
+extension WrapperManager: Authenticator {
   var isAuthenticated: Authenticated {
     socialAuthManager.isAuthenticated
   }

--- a/Sources/Apple/AppleAuthenticator+Models.swift
+++ b/Sources/Apple/AppleAuthenticator+Models.swift
@@ -33,6 +33,7 @@ public extension AppleAuthenticator {
   enum Error: Swift.Error {
     case system(_ error: Swift.Error)
     case cancelled
+    case signInInProgress
     case invalidIdentityToken
     case unhandledAuthorization
     case credentialsRevoked

--- a/Sources/Apple/AppleAuthenticator.swift
+++ b/Sources/Apple/AppleAuthenticator.swift
@@ -52,7 +52,7 @@ extension AppleAuthenticator: Authenticator {
   public func signOut() {
     storage.removeObject(forKey: storageUserIdKey)
     storage.setValue(false, forKey: storageAuthenticatedKey)
-    continuation = nil
+    resolveSignIn(with: .failure(Error.cancelled))
   }
   
   /// Returns the current authentication state.
@@ -131,7 +131,7 @@ extension AppleAuthenticator: ASAuthorizationControllerDelegate {
         expiresAt: expiresAt
       )
       
-      continuation?.resume(with: .success(response))
+      resolveSignIn(with: .success(response))
     case _:
       rejectSignIn(with: .unhandledAuthorization)
     }
@@ -153,10 +153,12 @@ extension AppleAuthenticator: ASAuthorizationControllerDelegate {
 // MARK: - Private Methods
 private extension AppleAuthenticator {
   func appleSignIn(on presentingViewController: UIViewController, with nonce: Nonce?) async throws -> Response {
+    guard continuation == nil else { throw Error.signInInProgress }
+
     let request = provider.createRequest()
-		request.requestedScopes = [.fullName, .email]
-		request.nonce = nonce?.value
-		
+    request.requestedScopes = [.fullName, .email]
+    request.nonce = nonce?.value
+
     return try await withCheckedThrowingContinuation { continuation in
       let controller = ASAuthorizationController(authorizationRequests: [request])
       controller.delegate = self
@@ -177,8 +179,13 @@ private extension AppleAuthenticator {
   
   func rejectSignIn(with error: Error) {
     storage.setValue(false, forKey: storageAuthenticatedKey)
-    continuation?.resume(throwing: error)
-    continuation = nil
+    resolveSignIn(with: .failure(error))
+  }
+
+  func resolveSignIn(with result: Result<Response, Swift.Error>) {
+    guard let continuation else { return }
+    continuation.resume(with: result)
+    self.continuation = nil
   }
 }
 

--- a/Sources/Core/Extensions/String+PovioKitAuth.swift
+++ b/Sources/Core/Extensions/String+PovioKitAuth.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  String+PovioKitAuth.swift
 //  PovioKitAuth
 //
 //  Created by Borut Tomazin on 10.12.2025.

--- a/Sources/Core/Models/Nonce.swift
+++ b/Sources/Core/Models/Nonce.swift
@@ -25,9 +25,9 @@ public extension Nonce {
 	
 	static func generateNonceString(length: UInt = 32) -> String {
 		guard length > 0 else { return "zero-length-nonce" }
-		let charset: [Character] = Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+		let charset: [Character] = Array("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-._")
 		let result = (0..<length).compactMap { _ in charset.randomElement() }
-		guard result.count == length else { fatalError("Unable to generate nonce!") }
+		guard result.count == length else { return UUID().uuidString.replacingOccurrences(of: "-", with: "") }
 		return String(result)
 	}
 }

--- a/Sources/LinkedIn/API/LinkedInAPI.swift
+++ b/Sources/LinkedIn/API/LinkedInAPI.swift
@@ -16,26 +16,22 @@ public struct LinkedInAPI {
 
 public extension LinkedInAPI {
   func login(with request: LinkedInAuthRequest) async throws -> LinkedInAuthResponse {
-    let encoder = JSONEncoder()
-    encoder.keyEncodingStrategy = .convertToSnakeCase
-    let jsonData = try encoder.encode(request)
-    let jsonObject = try JSONSerialization.jsonObject(with: jsonData, options: [])
-    guard let jsonDict = jsonObject as? [String: Any] else {
+    guard let url = URL(string: Endpoints.accessToken.url) else {
+      throw Error.invalidUrl
+    }
+
+    var components = URLComponents()
+    components.queryItems = [
+      .init(name: "grant_type", value: request.grantType),
+      .init(name: "code", value: request.code),
+      .init(name: "client_id", value: request.clientId),
+      .init(name: "client_secret", value: request.clientSecret),
+      .init(name: "redirect_uri", value: request.redirectUri)
+    ]
+    guard let bodyString = components.percentEncodedQuery else {
       throw Error.invalidRequest
     }
-    
-    guard var components = URLComponents(string: Endpoints.accessToken.url) else {
-      throw Error.invalidUrl
-    }
-    
-    let queryItems: [URLQueryItem] = jsonDict.compactMap { key, value in
-      (value as? String).map { .init(name: key, value: $0) }
-    }
-    
-    components.queryItems = queryItems
-    guard let url = components.url else {
-      throw Error.invalidUrl
-    }
+    let bodyData = Data(bodyString.utf8)
     
     let decoder = JSONDecoder()
     decoder.keyDecodingStrategy = .convertFromSnakeCase
@@ -48,7 +44,8 @@ public extension LinkedInAPI {
     let response = try await client.request(
       method: "POST",
       url: url,
-      headers: ["Content-Type": "application/x-www-form-urlencoded"],
+      headers: ["Content-Type": "application/x-www-form-urlencoded; charset=utf-8"],
+      body: bodyData,
       decodeTo: LinkedInAuthResponse.self,
       with: decoder
     )

--- a/Sources/LinkedIn/Core/HttpClient.swift
+++ b/Sources/LinkedIn/Core/HttpClient.swift
@@ -8,23 +8,33 @@
 
 import Foundation
 
+enum HttpClientError: Swift.Error {
+  case invalidResponse
+  case unsuccessfulStatusCode(code: Int, responseBody: Data)
+}
+
 struct HttpClient {
   func request<D: Decodable>(
     method: String,
     url: URL,
     headers: [String: String]?,
+    body: Data? = nil,
     decodeTo decode: D.Type,
     with decoder: JSONDecoder = .init()
   ) async throws -> D {
     var urlRequest = URLRequest(url: url)
     urlRequest.httpMethod = method
     urlRequest.allHTTPHeaderFields = headers
+    urlRequest.httpBody = body
     
     let (data, response) = try await URLSession.shared.data(for: urlRequest)
     
-    if let httpResponse = response as? HTTPURLResponse,
-       !(200...299).contains(httpResponse.statusCode) {
-      throw NSError(domain: "HTTP Error", code: httpResponse.statusCode, userInfo: nil)
+    guard let httpResponse = response as? HTTPURLResponse else {
+      throw HttpClientError.invalidResponse
+    }
+
+    guard (200...299).contains(httpResponse.statusCode) else {
+      throw HttpClientError.unsuccessfulStatusCode(code: httpResponse.statusCode, responseBody: data)
     }
     
     return try decoder.decode(decode, from: data)

--- a/Sources/LinkedIn/LinkedInAuthenticator+Models.swift
+++ b/Sources/LinkedIn/LinkedInAuthenticator+Models.swift
@@ -1,5 +1,5 @@
 //
-//  GoogleAuthenticator+Models.swift
+//  LinkedInAuthenticator+Models.swift
 //  PovioKitAuth
 //
 //  Created by Borut Tomazin on 30/01/2023.

--- a/Sources/LinkedIn/LinkedInAuthenticator.swift
+++ b/Sources/LinkedIn/LinkedInAuthenticator.swift
@@ -66,6 +66,6 @@ extension LinkedInAuthenticator: Authenticator {
   ///
   /// Call this from UIApplicationDelegate’s `application:openURL:options:` method.
   public func canOpenUrl(_ url: URL, application: UIApplication, options: [UIApplication.OpenURLOptionsKey : Any]) -> Bool {
-    true
+    false
   }
 }

--- a/Sources/LinkedIn/WebView/LinkedInWebView.swift
+++ b/Sources/LinkedIn/WebView/LinkedInWebView.swift
@@ -12,10 +12,10 @@ import SwiftUI
 @available(iOS 15.0, *)
 public struct LinkedInWebView: UIViewRepresentable {
   @Environment(\.dismiss) var dismiss
-  // create a random string based on the time interval (it will be in the number form) - Needed for state.
+  // Keep an unpredictable value for OAuth state validation.
   public typealias SuccessHandler = ((code: String, state: String)) -> Void
   public typealias ErrorHandler = () -> Void
-  private let requestState: String = "\(Int(Date().timeIntervalSince1970))"
+  private let requestState: String = UUID().uuidString.replacingOccurrences(of: "-", with: "")
   private let webView: WKWebView
   private let configuration: LinkedInAuthenticator.Configuration
   public let onSuccess: SuccessHandler?
@@ -37,6 +37,7 @@ public struct LinkedInWebView: UIViewRepresentable {
   }
   
   public func updateUIView(_ uiView: UIViewType, context: Context) {
+    guard !context.coordinator.didLoadInitialRequest else { return }
     guard let webView = uiView as? WKWebView else { return }
     guard let authURL = configuration.authorizationUrl(state: requestState) else {
       dismiss()
@@ -44,6 +45,7 @@ public struct LinkedInWebView: UIViewRepresentable {
     }
     webView.navigationDelegate = context.coordinator
     webView.load(.init(url: authURL))
+    context.coordinator.didLoadInitialRequest = true
   }
   
   public func makeCoordinator() -> Coordinator {
@@ -56,6 +58,7 @@ public extension LinkedInWebView {
   class Coordinator: NSObject, WKNavigationDelegate {
     private let parent: LinkedInWebView
     private let requestState: String
+    fileprivate var didLoadInitialRequest: Bool = false
     
     public init(_ parent: LinkedInWebView, requestState: String) {
       self.parent = parent
@@ -74,7 +77,7 @@ public extension LinkedInWebView {
       }
       
       // extract the authorization code from the redirect url
-      guard let url = webView.url,
+      guard let url = navigationAction.request.url,
             url.host == parent.configuration.redirectUrl.host,
             let components = URLComponents(string: url.absoluteString),
             let state = components.queryItems?.first(where: { $0.name == "state" })?.value,

--- a/Tests/Tests/Auth/Core/JWTDecoderEdgeCaseTests.swift
+++ b/Tests/Tests/Auth/Core/JWTDecoderEdgeCaseTests.swift
@@ -1,0 +1,54 @@
+//
+//  JWTDecoderEdgeCaseTests.swift
+//  PovioKitAuth_Tests
+//
+//  Created by Cursor on 10/04/2026.
+//
+
+import XCTest
+import Foundation
+import PovioKitAuthCore
+
+final class JWTDecoderEdgeCaseTests: XCTestCase {
+  func test_init_withInvalidStructure_throws() {
+    XCTAssertThrowsError(try JWTDecoder(token: "only.two"))
+  }
+
+  func test_bool_parsesBooleanFromStringPayload() throws {
+    let token = makeToken(header: ["alg": "HS256"], payload: ["email_verified": "true"])
+    let decoder = try JWTDecoder(token: token)
+
+    XCTAssertEqual(decoder.bool(for: "email_verified"), true)
+  }
+
+  func test_expiresAt_parsesStringDatePayload() throws {
+    let token = makeToken(header: ["alg": "HS256"], payload: ["exp": "1516239022"])
+    let decoder = try JWTDecoder(token: token)
+
+    XCTAssertEqual(decoder.expiresAt?.timeIntervalSince1970, 1516239022)
+  }
+
+  func test_isExpired_whenExpirationIsInPast_returnsTrue() throws {
+    let token = makeToken(header: ["alg": "HS256"], payload: ["exp": 1.0])
+    let decoder = try JWTDecoder(token: token)
+
+    XCTAssertTrue(decoder.isExpired)
+  }
+}
+
+private extension JWTDecoderEdgeCaseTests {
+  func makeToken(header: [String: Any], payload: [String: Any]) -> String {
+    let encodedHeader = encodeBase64URL(from: header)
+    let encodedPayload = encodeBase64URL(from: payload)
+    return "\(encodedHeader).\(encodedPayload).signature"
+  }
+
+  func encodeBase64URL(from object: [String: Any]) -> String {
+    let data = try! JSONSerialization.data(withJSONObject: object, options: [])
+    let base64 = data.base64EncodedString()
+    return base64
+      .replacingOccurrences(of: "+", with: "-")
+      .replacingOccurrences(of: "/", with: "_")
+      .replacingOccurrences(of: "=", with: "")
+  }
+}

--- a/Tests/Tests/Auth/Core/NonceTests.swift
+++ b/Tests/Tests/Auth/Core/NonceTests.swift
@@ -1,0 +1,22 @@
+//
+//  NonceTests.swift
+//  PovioKitAuth_Tests
+//
+//  Created by Cursor on 10/04/2026.
+//
+
+import XCTest
+import PovioKitAuthCore
+
+final class NonceTests: XCTestCase {
+  func test_customNonce_isHashedDeterministically() {
+    let nonce = Nonce.custom(value: "hello-world")
+    XCTAssertEqual(nonce.value, "afa27b44d43b02a9fea41d13cedc2e4016cfcf87c5dbf990e593669aa8ce286d")
+  }
+
+  func test_randomNonce_isSha256HexString() {
+    let nonce = Nonce.random(length: 16)
+    XCTAssertEqual(nonce.value.count, 64)
+    XCTAssertNotNil(nonce.value.range(of: "^[0-9a-f]{64}$", options: .regularExpression))
+  }
+}

--- a/Tests/Tests/Auth/Core/PersonNameComponentsTests.swift
+++ b/Tests/Tests/Auth/Core/PersonNameComponentsTests.swift
@@ -1,0 +1,36 @@
+//
+//  PersonNameComponentsTests.swift
+//  PovioKitAuth_Tests
+//
+//  Created by Cursor on 10/04/2026.
+//
+
+import XCTest
+import Foundation
+import PovioKitAuthCore
+
+final class PersonNameComponentsTests: XCTestCase {
+  func test_name_whenBothGivenAndFamilyAvailable_returnsFullName() {
+    var components = PersonNameComponents()
+    components.givenName = "Ada"
+    components.familyName = "Lovelace"
+    XCTAssertEqual(components.name, "Ada Lovelace")
+  }
+
+  func test_name_whenOnlyGivenNameAvailable_returnsGivenName() {
+    var components = PersonNameComponents()
+    components.givenName = "Ada"
+    XCTAssertEqual(components.name, "Ada")
+  }
+
+  func test_name_whenOnlyFamilyNameAvailable_returnsFamilyName() {
+    var components = PersonNameComponents()
+    components.familyName = "Lovelace"
+    XCTAssertEqual(components.name, "Lovelace")
+  }
+
+  func test_name_whenMissingBothGivenAndFamily_returnsNil() {
+    let components = PersonNameComponents()
+    XCTAssertNil(components.name)
+  }
+}

--- a/Tests/Tests/Auth/Core/SocialAuthenticationManagerTests.swift
+++ b/Tests/Tests/Auth/Core/SocialAuthenticationManagerTests.swift
@@ -1,0 +1,87 @@
+//
+//  SocialAuthenticationManagerTests.swift
+//  PovioKitAuth_Tests
+//
+//  Created by Cursor on 10/04/2026.
+//
+
+import XCTest
+import UIKit
+import PovioKitAuthCore
+
+final class SocialAuthenticationManagerTests: XCTestCase {
+  func test_isAuthenticated_whenAnyAuthenticatorIsAuthenticated_returnsTrue() {
+    let first = MockAuthenticator(isAuthenticated: false, canOpenUrlResult: false)
+    let second = MockAuthenticator(isAuthenticated: true, canOpenUrlResult: false)
+    let sut = SocialAuthenticationManager(authenticators: [first, second])
+
+    XCTAssertTrue(sut.isAuthenticated)
+  }
+
+  func test_currentAuthenticator_returnsFirstAuthenticatedAuthenticator() {
+    let first = MockAuthenticator(isAuthenticated: false, canOpenUrlResult: false)
+    let second = MockAuthenticator(isAuthenticated: true, canOpenUrlResult: false)
+    let third = MockAuthenticator(isAuthenticated: true, canOpenUrlResult: false)
+    let sut = SocialAuthenticationManager(authenticators: [first, second, third])
+
+    XCTAssertTrue(sut.currentAuthenticator as AnyObject === second)
+  }
+
+  func test_authenticatorFor_returnsRequestedType() {
+    let primary = PrimaryAuthenticator(isAuthenticated: false, canOpenUrlResult: false)
+    let secondary = SecondaryAuthenticator(isAuthenticated: true, canOpenUrlResult: false)
+    let sut = SocialAuthenticationManager(authenticators: [primary, secondary])
+
+    let resolved: SecondaryAuthenticator? = sut.authenticator(for: SecondaryAuthenticator.self)
+    XCTAssertNotNil(resolved)
+    XCTAssertTrue(resolved as AnyObject === secondary)
+  }
+
+  func test_signOut_callsAllAuthenticators() {
+    let first = MockAuthenticator(isAuthenticated: true, canOpenUrlResult: false)
+    let second = MockAuthenticator(isAuthenticated: false, canOpenUrlResult: false)
+    let sut = SocialAuthenticationManager(authenticators: [first, second])
+
+    sut.signOut()
+
+    XCTAssertEqual(first.signOutCalls, 1)
+    XCTAssertEqual(second.signOutCalls, 1)
+  }
+
+  @MainActor
+  func test_canOpenUrl_whenAnyAuthenticatorCanOpen_returnsTrue() {
+    let first = MockAuthenticator(isAuthenticated: false, canOpenUrlResult: false)
+    let second = MockAuthenticator(isAuthenticated: false, canOpenUrlResult: true)
+    let sut = SocialAuthenticationManager(authenticators: [first, second])
+
+    let canOpen = sut.canOpenUrl(
+      URL(string: "myapp://callback")!,
+      application: UIApplication.shared,
+      options: [:]
+    )
+
+    XCTAssertTrue(canOpen)
+  }
+}
+
+private class MockAuthenticator: Authenticator {
+  var isAuthenticated: Authenticated
+  var signOutCalls: Int = 0
+  let canOpenUrlResult: Bool
+
+  init(isAuthenticated: Bool, canOpenUrlResult: Bool) {
+    self.isAuthenticated = isAuthenticated
+    self.canOpenUrlResult = canOpenUrlResult
+  }
+
+  func signOut() {
+    signOutCalls += 1
+  }
+
+  func canOpenUrl(_ url: URL, application: UIApplication, options: [UIApplication.OpenURLOptionsKey : Any]) -> Bool {
+    canOpenUrlResult
+  }
+}
+
+private final class PrimaryAuthenticator: MockAuthenticator {}
+private final class SecondaryAuthenticator: MockAuthenticator {}


### PR DESCRIPTION
## Summary

This PR improves auth flow correctness, hardens security-related behavior, and expands test coverage across `Core` and `LinkedIn` modules.

### Core / Apple / LinkedIn improvements

- **Apple sign-in flow safety**
  - Added `AppleAuthenticator.Error.signInInProgress`.
  - Prevented overlapping Apple sign-in operations by failing fast when a flow is already active.
  - Centralized continuation completion through a single resolver path.
  - Ensured in-flight sign-in is cancelled cleanly on `signOut()`.

- **LinkedIn OAuth hardening**
  - Moved token exchange parameters from URL query string to **POST form body** (`application/x-www-form-urlencoded`).
  - Added optional request body support in `HttpClient`.
  - Replaced generic HTTP `NSError` with typed `HttpClientError` for clearer failure semantics.
  - Improved WebView OAuth state handling:
    - uses unpredictable `state` value,
    - validates redirect URL from the navigation action,
    - avoids reloading auth request on every SwiftUI update.
  - Updated `LinkedInAuthenticator.canOpenUrl` to return `false` (consistent with actual handling behavior).

- **Nonce and misc cleanup**
  - Fixed nonce character set typo (missing `W`).
  - Replaced `fatalError` nonce fallback with safe non-crashing fallback.
  - Corrected file/header naming inconsistencies in source files.

### Documentation updates

- Refreshed README usage examples to reflect current package composition:
  - removed stale Facebook usage from core examples,
  - switched examples to Apple + LinkedIn,
  - corrected manager API usage (`currentAuthenticator`),
  - corrected wrapper sample type naming.

### Test coverage expansion

Added focused tests to increase confidence and coverage:

- `JWTDecoderEdgeCaseTests`
- `NonceTests`
- `PersonNameComponentsTests`
- `SocialAuthenticationManagerTests`

These cover edge cases and branch paths for token decoding, nonce hashing behavior, name composition, and authenticator orchestration logic.

---

## Validation

- Built successfully for iOS simulator across package schemes.
- Test suite passes on iOS simulator:
  - all tests green for included test targets in this PR branch.

---

## Notes

- Changes are designed to be behavior-safe and backwards-compatible at API level, while improving correctness and observability.
- Security-sensitive auth request handling is now stricter (especially LinkedIn token exchange + OAuth state flow).